### PR TITLE
Modernize golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,27 +2,22 @@ version: "2"
 linters:
   default: standard
   enable:
+    - bodyclose
+    - prealloc
     - unparam
+  exclusions:
+    paths:
+      - generated.*\.go
+      - client
+      - vendor
 
 formatters:
   enable:
-    - gofmt
+    - gofumpt
     - goimports
-  settings:
-    gofmt:
-      rewrite-rules:
-        - pattern: 'interface{}'
-          replacement: 'any'
 
 issues:
   max-same-issues: 100
-
-  exclude-files:
-    - generated.*\\.go
-
-  exclude-dirs:
-    - client
-    - vendor
 
 run:
   timeout: 10m

--- a/apis/proxyserver/v1alpha1/register.go
+++ b/apis/proxyserver/v1alpha1/register.go
@@ -48,13 +48,15 @@ func Resource(resource string) schema.GroupResource {
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&LicenseRequest{},
 		&LicenseStatusList{},
 		&LicenseStatus{},
 	)
 
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&metav1.Status{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -81,7 +81,8 @@ func init() {
 
 	// TODO: keep the generic API server from wanting this
 	unversioned := schema.GroupVersion{Group: "", Version: "v1"}
-	Scheme.AddUnversionedTypes(unversioned,
+	Scheme.AddUnversionedTypes(
+		unversioned,
 		&metav1.Status{},
 		&metav1.APIVersions{},
 		&metav1.APIGroupList{},
@@ -193,7 +194,8 @@ func (c completedConfig) New(ctx context.Context) (*LicenseProxyServer, error) {
 			c.ExtraConfig.Token, cid,
 			c.ExtraConfig.CACert,
 			c.ExtraConfig.InsecureSkipTLSVerify,
-			fmt.Sprintf("license-proxyserver/%s", v.Version.Version))
+			fmt.Sprintf("license-proxyserver/%s", v.Version.Version),
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmds/server/start.go
+++ b/pkg/cmds/server/start.go
@@ -113,7 +113,8 @@ func (o *LicenseProxyServerOptions) Config() (*apiserver.Config, error) {
 		ou.GetDefinitions(
 			proxyv1alpha1.GetOpenAPIDefinitions,
 		),
-		openapi.NewDefinitionNamer(apiserver.Scheme))
+		openapi.NewDefinitionNamer(apiserver.Scheme),
+	)
 	serverConfig.OpenAPIConfig.Info.Title = "proxyserver"
 	serverConfig.OpenAPIConfig.Info.Version = v.Version.Version
 	serverConfig.OpenAPIConfig.IgnorePrefixes = ignorePrefixes
@@ -122,7 +123,8 @@ func (o *LicenseProxyServerOptions) Config() (*apiserver.Config, error) {
 		ou.GetDefinitions(
 			proxyv1alpha1.GetOpenAPIDefinitions,
 		),
-		openapi.NewDefinitionNamer(apiserver.Scheme))
+		openapi.NewDefinitionNamer(apiserver.Scheme),
+	)
 	serverConfig.OpenAPIV3Config.Info.Title = "proxyserver"
 	serverConfig.OpenAPIV3Config.Info.Version = v.Version.Version
 	serverConfig.OpenAPIV3Config.IgnorePrefixes = ignorePrefixes

--- a/pkg/cmds/server/start.go
+++ b/pkg/cmds/server/start.go
@@ -77,7 +77,7 @@ func (o LicenseProxyServerOptions) AddFlags(fs *pflag.FlagSet) {
 
 // Validate validates LicenseProxyServerOptions
 func (o LicenseProxyServerOptions) Validate(args []string) error {
-	var errors []error
+	errors := make([]error, 0, 2)
 	errors = append(errors, o.RecommendedOptions.Validate()...)
 	errors = append(errors, o.ExtraOptions.Validate()...)
 	return utilerrors.NewAggregate(errors)

--- a/pkg/controllers/secret/license_syncer.go
+++ b/pkg/controllers/secret/license_syncer.go
@@ -104,7 +104,8 @@ func (r *LicenseSyncer) addLicense(data []byte) error {
 	}
 
 	if time.Until(license.NotAfter.Time) >= storage.MinRemainingLife {
-		klog.InfoS("adding license",
+		klog.InfoS(
+			"adding license",
 			"licenseID", license.ID,
 			"product", license.ProductLine,
 			"plan", license.PlanName,

--- a/pkg/manager/license_acquirer.go
+++ b/pkg/manager/license_acquirer.go
@@ -148,7 +148,8 @@ func (r *LicenseAcquirer) reconcile(clusterName, cid string, features []string) 
 			l, c, err = r.getNewLicense(cid, []string{feature})
 			if err == nil {
 
-				klog.InfoS("acquired new license",
+				klog.InfoS(
+					"acquired new license",
 					"clusterName", clusterName,
 					"clusterUID", cid,
 					"licenseID", l.ID,

--- a/pkg/registry/proxyserver/licenserequest/storage.go
+++ b/pkg/registry/proxyserver/licenserequest/storage.go
@@ -176,7 +176,8 @@ func (r *Storage) getLicense(features []string) (*v1alpha1.License, error) {
 		return nil, err
 	}
 
-	klog.InfoS("adding license",
+	klog.InfoS(
+		"adding license",
 		"licenseID", l.ID,
 		"product", l.ProductLine,
 		"plan", l.PlanName,

--- a/pkg/storage/loader.go
+++ b/pkg/storage/loader.go
@@ -70,7 +70,8 @@ func LoadDir(cid, dir string, reg *LicenseRegistry) error {
 			klog.ErrorS(err, "Skipping", "file", filename)
 			continue
 		} else if time.Until(license.NotAfter.Time) >= MinRemainingLife {
-			klog.InfoS("adding license",
+			klog.InfoS(
+				"adding license",
 				"dir", dir,
 				"licenseID", license.ID,
 				"product", license.ProductLine,

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -123,7 +123,8 @@ func (r *LicenseRegistry) LicenseForFeature(feature string) (*v1alpha1.License, 
 			heap.Pop(&q)
 			r.reg[feature] = q
 
-			klog.InfoS("removing license",
+			klog.InfoS(
+				"removing license",
 				"licenseID", item.ID,
 				"product", item.ProductLine,
 				"plan", item.PlanName,


### PR DESCRIPTION
## Summary

Modernize the `.golangci.yml` configuration for golangci-lint v2 and switch the configured formatter to gofumpt.

This aligns the linter with the build image (`ghcr.io/appscode/golang-dev`), where `gofmt` is a shim to gofumpt — so `make fmt` (via `hack/fmt.sh`'s `gofmt -s -w`) and the linter now enforce the same formatting. No change to `hack/fmt.sh` is needed.

### `.golangci.yml`
- Enable **`bodyclose`** and **`prealloc`** linters (`unparam` was already enabled).
- Move `exclude-files` / `exclude-dirs` out of the deprecated `issues:` block into **`linters.exclusions.paths`** — the correct location in golangci-lint v2.
- Fix the over-escaped exclusion regex `generated.*\\.go` → `generated.*\.go`.
- Switch the formatter from **`gofmt` → `gofumpt`** and drop the now-unneeded `interface{}` → `any` rewrite rule (gofumpt performs this itself at go1.18+).

### Resulting formatting
- gofumpt reformatting applied across the affected Go files.
